### PR TITLE
fix: replace 4 bare excepts with except Exception

### DIFF
--- a/main.py
+++ b/main.py
@@ -422,7 +422,7 @@ class XianyuLive:
                     logger.info(f'交易成功 {user_url} 等待卖家发货')
                     return
 
-            except:
+            except Exception:
                 pass
 
             # 判断消息类型

--- a/utils/xianyu_utils.py
+++ b/utils/xianyu_utils.py
@@ -14,7 +14,7 @@ def trans_cookies(cookies_str: str) -> Dict[str, str]:
             parts = cookie.split('=', 1)
             if len(parts) == 2:
                 cookies[parts[0]] = parts[1]
-        except:
+        except Exception:
             continue
     return cookies
 
@@ -312,7 +312,7 @@ def decrypt(data: str) -> str:
                 if isinstance(obj, bytes):
                     try:
                         return obj.decode('utf-8')
-                    except:
+                    except Exception:
                         return base64.b64encode(obj).decode('utf-8')
                 elif hasattr(obj, '__dict__'):
                     return obj.__dict__
@@ -326,7 +326,7 @@ def decrypt(data: str) -> str:
             try:
                 text_result = decoded_bytes.decode('utf-8')
                 return json.dumps({"text": text_result})
-            except:
+            except Exception:
                 # 最后的备选方案：返回十六进制表示
                 hex_result = decoded_bytes.hex()
                 return json.dumps({"hex": hex_result, "error": f"Decode failed: {str(e)}"})


### PR DESCRIPTION
Replace 4 bare `except:` with `except Exception:`. Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, masking real errors.