### PR TITLE
feat: 支持多模型提供商切换 (MiniMax M3/OpenAI/DeepSeek)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,24 @@ MODEL_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
 MODEL_NAME=qwen-max
 TOGGLE_KEYWORDS=。
 SIMULATE_HUMAN_TYPING=False
+# 是否启用搜索增强（仅阿里云DashScope支持），使用其他模型提供商时请设为False
+ENABLE_SEARCH=True
+
+# ===== 其他模型提供商配置示例 =====
+# --- MiniMax ---
+# API_KEY=your_minimax_api_key
+# MODEL_BASE_URL=https://api.minimax.io/v1
+# MODEL_NAME=MiniMax-M2.5
+# ENABLE_SEARCH=False
+#
+# --- OpenAI ---
+# API_KEY=your_openai_api_key
+# MODEL_BASE_URL=https://api.openai.com/v1
+# MODEL_NAME=gpt-4o
+# ENABLE_SEARCH=False
+#
+# --- DeepSeek ---
+# API_KEY=your_deepseek_api_key
+# MODEL_BASE_URL=https://api.deepseek.com/v1
+# MODEL_NAME=deepseek-chat
+# ENABLE_SEARCH=False

--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@ ENABLE_SEARCH=True
 # --- MiniMax ---
 # API_KEY=your_minimax_api_key
 # MODEL_BASE_URL=https://api.minimax.io/v1
-# MODEL_NAME=MiniMax-M2.5
+# MODEL_NAME=MiniMax-M2.7
 # ENABLE_SEARCH=False
 #
 # --- OpenAI ---

--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@ ENABLE_SEARCH=True
 # --- MiniMax ---
 # API_KEY=your_minimax_api_key
 # MODEL_BASE_URL=https://api.minimax.io/v1
-# MODEL_NAME=MiniMax-M2.7
+# MODEL_NAME=MiniMax-M3
 # ENABLE_SEARCH=False
 #
 # --- OpenAI ---

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ SIMULATE_HUMAN_TYPING=True/False #模拟人工回复延迟
 注意：默认使用的模型是通义千问，如需使用其他API，请自行修改.env文件中的模型地址和模型名称；
 COOKIES_STR自行在闲鱼网页端获取cookies(网页端F12打开控制台，选择Network，点击Fetch/XHR,点击一个请求，查看cookies)
 
+注：使用非DashScope模型（如MiniMax、OpenAI、DeepSeek等）时，请将 ENABLE_SEARCH 设为 False，
+因为搜索增强为DashScope特有功能。
+
 4. 创建提示词文件prompts/*_prompt.txt（也可以直接将模板名称中的_example去掉），否则默认读取四个提示词模板中的内容
 ```
 
@@ -94,6 +97,19 @@ python main.py
 - `price_prompt.txt`: 价格专家提示词
 - `tech_prompt.txt`: 技术专家提示词
 - `default_prompt.txt`: 默认回复提示词
+
+## 🔌 支持的模型提供商
+
+本项目基于 OpenAI 兼容接口，支持多种大模型提供商。只需修改 `.env` 中的 `API_KEY`、`MODEL_BASE_URL` 和 `MODEL_NAME` 即可切换：
+
+| 提供商 | MODEL_BASE_URL | 推荐模型 | 备注 |
+|--------|---------------|----------|------|
+| 通义千问 (默认) | `https://dashscope.aliyuncs.com/compatible-mode/v1` | `qwen-max` | 支持搜索增强 |
+| [MiniMax](https://www.minimaxi.com/) | `https://api.minimax.io/v1` | `MiniMax-M2.5` | 204K上下文，高性价比 |
+| OpenAI | `https://api.openai.com/v1` | `gpt-4o` | |
+| DeepSeek | `https://api.deepseek.com/v1` | `deepseek-chat` | |
+
+> 💡 任何兼容 OpenAI API 的模型提供商均可使用，只需配置对应的 `MODEL_BASE_URL` 和 `MODEL_NAME`。
 
 ## 🤝 参与贡献
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ python main.py
 | 提供商 | MODEL_BASE_URL | 推荐模型 | 备注 |
 |--------|---------------|----------|------|
 | 通义千问 (默认) | `https://dashscope.aliyuncs.com/compatible-mode/v1` | `qwen-max` | 支持搜索增强 |
-| [MiniMax](https://www.minimaxi.com/) | `https://api.minimax.io/v1` | `MiniMax-M2.5` | 204K上下文，高性价比 |
+| [MiniMax](https://www.minimaxi.com/) | `https://api.minimax.io/v1` | `MiniMax-M2.7` | 204K上下文，高性价比 |
 | OpenAI | `https://api.openai.com/v1` | `gpt-4o` | |
 | DeepSeek | `https://api.deepseek.com/v1` | `deepseek-chat` | |
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ python main.py
 | 提供商 | MODEL_BASE_URL | 推荐模型 | 备注 |
 |--------|---------------|----------|------|
 | 通义千问 (默认) | `https://dashscope.aliyuncs.com/compatible-mode/v1` | `qwen-max` | 支持搜索增强 |
-| [MiniMax](https://www.minimaxi.com/) | `https://api.minimax.io/v1` | `MiniMax-M2.7` | 204K上下文，高性价比 |
+| [MiniMax](https://www.minimaxi.com/) | `https://api.minimax.io/v1` | `MiniMax-M3` | 512K上下文，128K最大输出，支持图片输入 |
 | OpenAI | `https://api.openai.com/v1` | `gpt-4o` | |
 | DeepSeek | `https://api.deepseek.com/v1` | `deepseek-chat` | |
 

--- a/XianyuAgent.py
+++ b/XianyuAgent.py
@@ -219,6 +219,14 @@ class BaseAgent:
             {"role": "user", "content": user_msg}
         ]
 
+    @staticmethod
+    def _strip_think_tags(text: str) -> str:
+        """移除模型返回的思考过程标签（如 <think>...</think>）"""
+        if not text:
+            return text
+        cleaned = re.sub(r'<think>.*?</think>\s*', '', text, flags=re.DOTALL)
+        return cleaned.strip()
+
     def _call_llm(self, messages: List[Dict], temperature: float = 0.4) -> str:
         """调用大模型"""
         response = self.client.chat.completions.create(
@@ -228,7 +236,8 @@ class BaseAgent:
             max_tokens=500,
             top_p=0.8
         )
-        return response.choices[0].message.content
+        content = response.choices[0].message.content
+        return self._strip_think_tags(content)
 
 
 class PriceAgent(BaseAgent):
@@ -247,7 +256,8 @@ class PriceAgent(BaseAgent):
             max_tokens=500,
             top_p=0.8
         )
-        return self.safety_filter(response.choices[0].message.content)
+        content = self._strip_think_tags(response.choices[0].message.content)
+        return self.safety_filter(content)
 
     def _calc_temperature(self, bargain_count: int) -> float:
         """动态温度策略"""
@@ -261,18 +271,23 @@ class TechAgent(BaseAgent):
         messages = self._build_messages(user_msg, item_desc, context)
         # messages[0]['content'] += "\n▲知识库：\n" + self._fetch_tech_specs()
 
-        response = self.client.chat.completions.create(
-            model=os.getenv("MODEL_NAME", "qwen-max"),
-            messages=messages,
-            temperature=0.4,
-            max_tokens=500,
-            top_p=0.8,
-            extra_body={
-                "enable_search": True,
-            }
-        )
+        kwargs = {
+            "model": os.getenv("MODEL_NAME", "qwen-max"),
+            "messages": messages,
+            "temperature": 0.4,
+            "max_tokens": 500,
+            "top_p": 0.8,
+        }
 
-        return self.safety_filter(response.choices[0].message.content)
+        # enable_search 为阿里云DashScope特有功能，其他模型提供商不支持
+        # 通过环境变量 ENABLE_SEARCH 控制，默认开启以兼容原有行为
+        if os.getenv("ENABLE_SEARCH", "True").lower() == "true":
+            kwargs["extra_body"] = {"enable_search": True}
+
+        response = self.client.chat.completions.create(**kwargs)
+
+        content = self._strip_think_tags(response.choices[0].message.content)
+        return self.safety_filter(content)
 
 
     # def _fetch_tech_specs(self) -> str:


### PR DESCRIPTION
## Summary

本项目目前默认使用阿里云 DashScope（通义千问），但其 OpenAI 兼容接口架构天然支持多种模型提供商。本 PR 增强了多提供商兼容性，主要改动：

- **新增 `ENABLE_SEARCH` 环境变量**：`TechAgent` 中 `enable_search` 为 DashScope 特有功能，使用 MiniMax / OpenAI / DeepSeek 等其他提供商时会导致兼容性问题。通过环境变量控制，默认开启以保持向后兼容
- **新增 `_strip_think_tags` 方法**：部分模型（如 MiniMax）会在回复中包含 `<think>...</think>` 推理过程标签，直接发送给用户会影响体验。新增过滤方法自动移除这些标签
- **升级 MiniMax 推荐模型为 M3**：将 README 表格和 `.env.example` 中的推荐模型从 `MiniMax-M2.7` 升级为 `MiniMax-M3`（512K 上下文，128K 最大输出，支持图片输入）。`MiniMax-M2.7` / `MiniMax-M2.7-highspeed` 仍可通过修改 `MODEL_NAME` 使用
- **文档和配置示例**：在 README 中添加支持的模型提供商表格，在 `.env.example` 中添加 MiniMax、OpenAI、DeepSeek 的配置示例

### 已测试的提供商

| 提供商 | MODEL_BASE_URL | 推荐模型 | 测试状态 |
|--------|---------------|----------|----------|
| MiniMax | `https://api.minimax.io/v1` | `MiniMax-M3` | Tested |
| 通义千问 | `https://dashscope.aliyuncs.com/compatible-mode/v1` | `qwen-max` | Default |

## Changes
- Add `ENABLE_SEARCH` env var to control DashScope-specific search feature
- Add `_strip_think_tags()` to filter `<think>` reasoning tags from model responses
- Upgrade recommended MiniMax model from M2.7 to M3
- Update `.env.example` with MiniMax (M3), OpenAI, DeepSeek config examples
- Update README supported providers table to recommend MiniMax-M3

## Why
MiniMax-M3 是最新一代模型，512K 上下文窗口，128K 最大输出，并支持图片输入，相比 M2.7 在长上下文和推理能力上均有提升。

## API Documentation
- MiniMax OpenAI Compatible API: https://platform.minimax.io/docs/api-reference/text-openai-api