### PR TITLE
fix: remove duplicate ACK in handle_message to prevent message re-delivery

### DIFF
--- a/main.py
+++ b/main.py
@@ -357,25 +357,6 @@ class XianyuLive:
         """处理所有类型的消息"""
         try:
 
-            try:
-                message = message_data
-                ack = {
-                    "code": 200,
-                    "headers": {
-                        "mid": message["headers"]["mid"] if "mid" in message["headers"] else generate_mid(),
-                        "sid": message["headers"]["sid"] if "sid" in message["headers"] else '',
-                    }
-                }
-                if 'app-key' in message["headers"]:
-                    ack["headers"]["app-key"] = message["headers"]["app-key"]
-                if 'ua' in message["headers"]:
-                    ack["headers"]["ua"] = message["headers"]["ua"]
-                if 'dt' in message["headers"]:
-                    ack["headers"]["dt"] = message["headers"]["dt"]
-                await websocket.send(json.dumps(ack))
-            except Exception as e:
-                pass
-
             # 如果不是同步包消息，直接返回
             if not self.is_sync_package(message_data):
                 return


### PR DESCRIPTION
Fixes #66

## Problem

The `main()` loop already sends an ACK response for every incoming WebSocket message that contains a `mid` header (lines 654–667). However, `handle_message()` was sending a **second, identical ACK** at the start of every call before doing any processing.

This means the server received **two ACKs per message**. Many WebSocket-based messaging protocols interpret a duplicate ACK as a sign that the original delivery failed, and respond by **re-sending the same message** with a new delivery timestamp. This can cause:
- The bot to process the same buyer message multiple times
- Multiple AI-generated replies sent to a single buyer message
- Unexpected memory growth from message storms under high traffic

## Solution

Remove the redundant ACK block (19 lines) from `handle_message()`. The `main()` loop already handles ACKs for all messages — including the `app-key`, `ua`, and `dt` header fields — so no functionality is lost.

## Testing

- Verified that `main()` sends the ACK before calling `handle_message()`, covering all cases.
- Heartbeat responses are handled separately via `handle_heartbeat_response()` and do not go through `handle_message()`, so they are unaffected.
- The change is a pure deletion with no new logic introduced.